### PR TITLE
#GJ-213, see details.

### DIFF
--- a/.env
+++ b/.env
@@ -1,0 +1,1 @@
+ELASTICSEARCH_HOST=elasticsearch

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -19,15 +19,19 @@ services:
       - MAX_LOCKED_MEMORY=unlimited
 
   starchat:
-    image: elegansio/starchat:5.0.0-beta7
+    image: getjenny/starchat:5.0.0-beta7
     restart: unless-stopped
-    command: ["/starchat/scripts/utils/wait-for-it.sh", "getjenny-es", "9200", "10", "/starchat/bin/starchat"]
+    command: ["/starchat/scripts/utils/wait-for-it.sh", "${ELASTICSEARCH_HOST}", "9200", "10", "/starchat/bin/starchat"]
     volumes:
       - ./starchat/config:/starchat/config
       - ./starchat/log:/starchat/log
     ports:
       - "0.0.0.0:8888:8888"
       - "0.0.0.0:8443:8443"
-    links:
-      - "elasticsearch:getjenny-es"
+    healthcheck:
+      test: curl -f http://localhost:8888/ || exit 1
+      interval: 1m30s
+      timeout: 10s
+      retries: 3
+      start_period: 30s
 


### PR DESCRIPTION
- added healtcheck
- externalize elasticsearch host, with sane default (.env)
- links is redundant.