### PR TITLE
increase docker-compose file version

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,4 +1,4 @@
-version: "3.2"
+version: "3.4"
 services:
 
   elasticsearch:


### PR DESCRIPTION
**The Problem:**
the current docker file version does not allow `start_period` addictional property:

<img width="743" alt="screenshot 2018-10-29 at 17 07 33" src="https://user-images.githubusercontent.com/10383300/47664101-a2f3c300-db9e-11e8-8f29-de11e5cfa25d.png">

**Proposed Solution**
Upgrading to `3.4` seems to fix the issue